### PR TITLE
Add some CSS 3 attribute selectors

### DIFF
--- a/lib/CSS/Grammar/CSS3.pm
+++ b/lib/CSS/Grammar/CSS3.pm
@@ -24,3 +24,7 @@ rule misplaced     {<charset>|<import>|<at-decl>}
 # 'lexer' css3 exceptions
 token nonascii     {<- [\x0..\x7F]>}
 
+# Selector Level 3 attribute operators
+token attribute-selector:sym<startswith> {'^='}
+token attribute-selector:sym<endswith>   {'$='}
+token attribute-selector:sym<contains>   {'*='}


### PR DESCRIPTION
I added `^=`, `$=`, and `*=` to the CSS 3 grammar.  There are no tests; I wasn't sure about the best way to go about adding them, but I'll add them if you'd like!